### PR TITLE
wrapper: handle EINTR from internall poll() in x[read|write]

### DIFF
--- a/wrapper.c
+++ b/wrapper.c
@@ -213,10 +213,12 @@ static int handle_nonblock(int fd, short poll_events, int err)
 	pfd.events = poll_events;
 
 	/*
-	 * no need to check for errors, here;
+	 * no need to check for errors except for EINTR, here;
 	 * a subsequent read/write will detect unrecoverable errors
 	 */
-	poll(&pfd, 1, -1);
+	while (poll(&pfd, 1, -1) < 0)
+		if (errno == EINTR)
+			continue;
 	return 1;
 }
 


### PR DESCRIPTION
Since 1079c4be0b (xread: poll on non blocking fds, 2015-12-15) a poll() was introduced to xread to wait when a O_NONBLOCK fd was being used, similar logic was later added for xwrite and eventually factored out, while retaining the same logic.

An EINTR in poll() doesn't indicate a change on the status of the fd that is being read/written to, and therefore it should be handled internally.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
